### PR TITLE
refactored composer scripts to clearly mark ci actions and their limits,

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -11,7 +11,6 @@ jobs:
   infection:
     runs-on: ubuntu-latest
     name: Infection
-    needs: build
     permissions:
       checks: write
     steps:

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
+      - name: Install infection
+        run: composer install-infection-phar
+
       - name: Run infection tests
         run: composer ci-infection
 

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
       - name: Run infection tests
         run: composer ci-infection
 

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -1,5 +1,4 @@
-name: Composer checks
-
+name: Infection mutation tests
 on:
   pull_request:
     branches: [ "main" ]
@@ -7,11 +6,12 @@ on:
 permissions:
   contents: read
 
+
 jobs:
-  build:
-    name: Platform checks
+  infection:
     runs-on: ubuntu-latest
-    #    runs-on: self-hosted
+    name: Infection
+    needs: build
     permissions:
       checks: write
     steps:
@@ -22,9 +22,6 @@ jobs:
         with:
           php-version: '8.2'
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict --no-check-lock
-
       - name: Get Date
         id: get-date
         run: |
@@ -33,22 +30,10 @@ jobs:
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3
-        id: cache
         with:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
+      - name: Run infection tests
+        run: composer ci-infection
 
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: composer install --prefer-dist --no-progress
-
-      - name: Check PHP
-        run: composer check-platform-reqs
-
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: PHP Checks
 
 on:
   pull_request:
@@ -79,10 +79,18 @@ jobs:
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
       - name: Run phpunit tests
-        run: composer phpunit
+        run: composer ci-phpunit
+
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: PHPUnit
+          path: ./phpunit.xml
+          reporter: java-junit
 
       - name: Run infection tests
-        run: composer infection-auto
+        run: composer ci-infection
 
   style:
     runs-on: ubuntu-latest
@@ -109,7 +117,18 @@ jobs:
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
       - name: Run php-cs-fixer checks
-        run: composer php-cs-fixer-check
+        run: |
+          composer ci-php-cs-fixer 1> php-cs-fixer.xml
+        shell: bash
+
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: php-cs-fixer
+          path: ./php-cs-fixer.xml
+          reporter: java-junit
+
   standards:
     runs-on: ubuntu-latest
     name: Check standards
@@ -135,4 +154,30 @@ jobs:
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
       - name: Run phpstan tests
-        run: composer phpstan-check
+        run: composer ci-phpstan
+  insights:
+    runs-on: ubuntu-latest
+    name: Check insights
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
+
+      - name: Run phpinsights
+        run: composer ci-phpinsights

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Checks
+name: PHP Checks (composer,phpunit,infection,phpstan,phpcsfixer,phpinsights)
 
 on:
   pull_request:
@@ -52,7 +52,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: PHPUnit
+          name: PHPUnit report
           path: ./phpunit-log.xml
           reporter: java-junit
 
@@ -125,7 +125,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: php-cs-fixer
+          name: php-cs-fixer report
           path: ./php-cs-fixer.xml
           reporter: java-junit
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,8 @@ jobs:
     name: Build and unit test
     runs-on: ubuntu-latest
     #    runs-on: self-hosted
-
+    permissions:
+      checks: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -183,5 +183,8 @@ jobs:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
       - name: Run phpinsights
         run: composer ci-phpinsights

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -93,8 +93,11 @@ jobs:
 
       - name: Run infection tests
         run: |
+          echo "test"
           composer ci-infection
           cat /tmp/infection/phpunitConfiguration.initial.infection.xml
+          ls -alh /tmp/infection
+          echo "end test"
         shell: bash
 
   style:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,16 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Check PHP
-        run: composer check-platform-reqs
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
+
+      - name: Check PHP
+        run: composer check-platform-reqs
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict --no-check-lock
 
       - name: Get Date
         id: get-date
@@ -43,6 +43,7 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress
+
 
       - name: Install infection
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -53,7 +53,7 @@ jobs:
 
   unit:
     runs-on: ubuntu-latest
-    name: Phpunit and infection
+    name: Phpunit
     needs: build
     permissions:
       checks: write
@@ -90,7 +90,7 @@ jobs:
 
   infection:
     runs-on: ubuntu-latest
-    name: Phpunit and infection
+    name: Infection
     needs: build
     permissions:
       checks: write

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Check PHP
+        run: composer check-platform-reqs
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -48,13 +54,8 @@ jobs:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
-      - name: Check PHP
-        run: composer check-platform-reqs
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict
-
-  test:
+  unit:
     runs-on: ubuntu-latest
     name: Phpunit and infection
     needs: build
@@ -88,17 +89,36 @@ jobs:
         if: success() || failure()
         with:
           name: PHPUnit
-          path: ./phpunit.xml
+          path: ./phpunit-log.xml
           reporter: java-junit
 
-      - name: Run infection tests
+  infection:
+    runs-on: ubuntu-latest
+    name: Phpunit and infection
+    needs: build
+    permissions:
+      checks: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Get Date
+        id: get-date
         run: |
-          echo "test"
-          composer ci-infection
-          cat /tmp/infection/phpunitConfiguration.initial.infection.xml
-          ls -alh /tmp/infection
-          echo "end test"
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
         shell: bash
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
+      - name: Run infection tests
+        run: composer ci-infection
 
   style:
     runs-on: ubuntu-latest

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           composer ci-infection
           cat /tmp/infection/phpunitConfiguration.initial.infection.xml
-        script: bash
+        shell: bash
 
   style:
     runs-on: ubuntu-latest

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build:
-    name: Build app and unit test
+    name: Build and unit test
     runs-on: ubuntu-latest
     #    runs-on: self-hosted
 
@@ -44,39 +44,6 @@ jobs:
       - name: Check PHP
         run: composer check-platform-reqs
 
-      - name: Cache Composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
-
-
-  unit:
-    runs-on: ubuntu-latest
-    name: Phpunit
-    needs: build
-    permissions:
-      checks: write
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-
-      - name: Get Date
-        id: get-date
-        run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-        shell: bash
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
-
       - name: Run phpunit tests
         run: composer ci-phpunit
 
@@ -87,6 +54,12 @@ jobs:
           name: PHPUnit
           path: ./phpunit-log.xml
           reporter: java-junit
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
   infection:
     runs-on: ubuntu-latest

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Phpunit and infection
     needs: build
+    permissions:
+      checks: write
     steps:
       - uses: actions/checkout@v3
 
@@ -96,6 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check coding style
     needs: build
+    permissions:
+      checks: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -92,7 +92,10 @@ jobs:
           reporter: java-junit
 
       - name: Run infection tests
-        run: composer ci-infection
+        run: |
+          composer ci-infection
+          cat /tmp/infection/phpunitConfiguration.initial.infection.xml
+        script: bash
 
   style:
     runs-on: ubuntu-latest

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build:
-
+    name: Build app and unit test
     runs-on: ubuntu-latest
     #    runs-on: self-hosted
 
@@ -20,9 +20,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
-
-      - name: Check PHP
-        run: composer check-platform-reqs
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict --no-check-lock
@@ -44,10 +41,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress
 
-
-      - name: Install infection
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: composer install-infection-phar
+      - name: Check PHP
+        run: composer check-platform-reqs
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -10,7 +10,6 @@ jobs:
   style:
     runs-on: ubuntu-latest
     name: Check coding style
-    needs: build
     permissions:
       checks: write
     steps:

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -32,6 +32,10 @@ jobs:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress
+
       - name: Run php-cs-fixer checks
         run: |
           composer ci-php-cs-fixer 1> php-cs-fixer.xml

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -1,5 +1,4 @@
-name: Composer checks
-
+name: PHP Style checks
 on:
   pull_request:
     branches: [ "main" ]
@@ -8,10 +7,10 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Platform checks
+  style:
     runs-on: ubuntu-latest
-    #    runs-on: self-hosted
+    name: Check coding style
+    needs: build
     permissions:
       checks: write
     steps:
@@ -22,9 +21,6 @@ jobs:
         with:
           php-version: '8.2'
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict --no-check-lock
-
       - name: Get Date
         id: get-date
         run: |
@@ -33,22 +29,19 @@ jobs:
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3
-        id: cache
         with:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: composer install --prefer-dist --no-progress
+      - name: Run php-cs-fixer checks
+        run: |
+          composer ci-php-cs-fixer 1> php-cs-fixer.xml
+        shell: bash
 
-      - name: Check PHP
-        run: composer check-platform-reqs
-
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v3
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
         with:
-          path: vendor
-          key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
-
+          name: php-cs-fixer report
+          path: ./php-cs-fixer.xml
+          reporter: java-junit

--- a/.github/workflows/phpinsights.yml
+++ b/.github/workflows/phpinsights.yml
@@ -25,13 +25,11 @@ jobs:
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3
-        id: cache
         with:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress
 
       - name: Run phpinsights

--- a/.github/workflows/phpinsights.yml
+++ b/.github/workflows/phpinsights.yml
@@ -9,7 +9,6 @@ jobs:
   insights:
     runs-on: ubuntu-latest
     name: Check insights
-    needs: build
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/phpinsights.yml
+++ b/.github/workflows/phpinsights.yml
@@ -25,11 +25,13 @@ jobs:
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3
+        id: cache
         with:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress
 
       - name: Run phpinsights

--- a/.github/workflows/phpinsights.yml
+++ b/.github/workflows/phpinsights.yml
@@ -1,5 +1,3 @@
-name: Composer checks
-
 on:
   pull_request:
     branches: [ "main" ]
@@ -8,12 +6,10 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Platform checks
+  insights:
     runs-on: ubuntu-latest
-    #    runs-on: self-hosted
-    permissions:
-      checks: write
+    name: Check insights
+    needs: build
     steps:
       - uses: actions/checkout@v3
 
@@ -21,9 +17,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict --no-check-lock
 
       - name: Get Date
         id: get-date
@@ -33,22 +26,12 @@ jobs:
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3
-        id: cache
         with:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress
 
-      - name: Check PHP
-        run: composer check-platform-reqs
-
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
-
+      - name: Run phpinsights
+        run: composer ci-phpinsights

--- a/.github/workflows/phpinsights.yml
+++ b/.github/workflows/phpinsights.yml
@@ -1,3 +1,4 @@
+name: PHPInsights checks
 on:
   pull_request:
     branches: [ "main" ]

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,4 +1,4 @@
-name: PHP phpstan checks
+name: PHPstan checks
 on:
   pull_request:
     branches: [ "main" ]

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -26,9 +26,14 @@ jobs:
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3
+        id: cache
         with:
           path: vendor
           key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress
 
       - name: Run phpstan tests
         run: composer ci-phpstan

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -10,7 +10,6 @@ jobs:
   standards:
     runs-on: ubuntu-latest
     name: Check standards
-    needs: build
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,35 @@
+name: PHP phpstan checks
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  standards:
+    runs-on: ubuntu-latest
+    name: Check standards
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-${{steps.get-date.outputs.date}}
+
+      - name: Run phpstan tests
+        run: composer ci-phpstan

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     permissions:
       checks: write
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,4 @@
-name: Composer checks
-
+name: PHPunit tests
 on:
   pull_request:
     branches: [ "main" ]
@@ -9,9 +8,6 @@ permissions:
 
 jobs:
   build:
-    name: Platform checks
-    runs-on: ubuntu-latest
-    #    runs-on: self-hosted
     permissions:
       checks: write
     steps:
@@ -21,9 +17,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict --no-check-lock
 
       - name: Get Date
         id: get-date
@@ -42,9 +35,16 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress
 
-      - name: Check PHP
-        run: composer check-platform-reqs
+      - name: Run phpunit tests
+        run: composer ci-phpunit
 
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: PHPUnit report
+          path: ./phpunit-log.xml
+          reporter: java-junit
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PHP Checks (composer,phpunit,infection,phpstan,phpcsfixer,phpinsights)](https://github.com/meltir/imdb-review-scraper/actions/workflows/php.yml/badge.svg)](https://github.com/meltir/imdb-review-scraper/actions/workflows/php.yml)  
+
 # What is this thing ?
 Hi, I'm Lukasz. I code. This is a thing I coded.  
 This is an experiment/exercise in building a composer package, and setting it up with a full deployment lifecycle.  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-[![PHP Checks (composer,phpunit,infection,phpstan,phpcsfixer,phpinsights)](https://github.com/meltir/imdb-review-scraper/actions/workflows/php.yml/badge.svg)](https://github.com/meltir/imdb-review-scraper/actions/workflows/php.yml)  
+[![Composer checks](https://github.com/meltir/imdb-review-scraper/actions/workflows/php.yml/badge.svg)](https://github.com/meltir/imdb-review-scraper/actions/workflows/php.yml) 
+[![Infection tests](https://github.com/meltir/imdb-review-scraper/actions/workflows/infection.yml/badge.svg)](https://github.com/meltir/imdb-review-scraper/actions/workflows/infection.yml) 
+[![PHP cs fixer check](https://github.com/meltir/imdb-review-scraper/actions/workflows/phpcsfixer.yml/badge.svg)](https://github.com/meltir/imdb-review-scraper/actions/workflows/phpcsfixer.yml) 
+[![PHPinsights](https://github.com/meltir/imdb-review-scraper/actions/workflows/phpinsights.yml/badge.svg)](https://github.com/meltir/imdb-review-scraper/actions/workflows/phpinsights.yml) 
+[![PHPStan](https://github.com/meltir/imdb-review-scraper/actions/workflows/phpstan.yml/badge.svg)](https://github.com/meltir/imdb-review-scraper/actions/workflows/phpstan.yml)  [![PHPUnit](https://github.com/meltir/imdb-review-scraper/actions/workflows/phpunit.yml/badge.svg)](https://github.com/meltir/imdb-review-scraper/actions/workflows/phpunit.yml)  
+
 
 # What is this thing ?
 Hi, I'm Lukasz. I code. This is a thing I coded.  

--- a/composer.json
+++ b/composer.json
@@ -53,11 +53,11 @@
         ],
 
         "ci-phpunit" : [
-            "@phpunit --log-junit=./phpunit.xml"
+            "@phpunit --log-junit=./phpunit-log.xml"
         ],
 
         "ci-infection": [
-            "@infection --min-msi=95 --min-covered-msi=95 --debug"
+            "@infection --min-msi=95 --min-covered-msi=95 --logger-github"
         ],
 
         "ci-php-cs-fixer": [

--- a/composer.json
+++ b/composer.json
@@ -25,32 +25,64 @@
             "Composer\\Config::disableProcessTimeout",
             "./vendor/bin/phpunit"
         ],
-        "infection-auto": [
+
+        "phpstan" : [
+            "./vendor/bin/phpstan"
+        ],
+
+        "infection": [
             "Composer\\Config::disableProcessTimeout",
-            "./vendor/bin/infection.phar --ignore-msi-with-no-mutations --only-covered --min-msi=95 --min-covered-msi=95"
+            "./vendor/bin/infection.phar --ignore-msi-with-no-mutations --only-covered"
         ],
-        "install-infection-phar" : [
-            "@php -r \"copy('https://github.com/infection/infection/releases/download/0.26.21/infection.phar', 'vendor/bin/infection.phar');\"",
-            "chmod +x vendor/bin/infection.phar"
-        ],
-        "install-git-hooks": [
-            "cp .github/hooks/* .git/hooks/",
-            "chmod +x .git/hooks/*"
-        ],
-        "post-install-cmd": [
-            "@install-infection-phar",
-            "@install-git-hooks"
-        ],
-        "php-cs-fixer-check": [
+
+        "php-cs-fixer": [
             "./vendor/bin/php-cs-fixer fix --using-cache=no --config=.php-cs-fixer.dist.php --dry-run --verbose --diff"
         ],
+
         "php-cs-fixer-fix": [
             "./vendor/bin/php-cs-fixer fix --using-cache=no --config=.php-cs-fixer.dist.php"
         ],
 
-        "phpstan-check" : [
-            "./vendor/bin/phpstan"
+        "phpinsights": [
+            "Composer\\Config::disableProcessTimeout",
+            "./vendor/bin/phpinsights"
+        ],
+
+        "ci-phpinsights": [
+            "@phpinsights --min-quality=95  --min-complexity=70 --min-architecture=80 --min-style=80 --format=github-action"
+        ],
+
+        "ci-phpunit" : [
+            "@phpunit --log-junit=./phpunit.xml"
+        ],
+
+        "ci-infection": [
+            "@infection --min-msi=95 --min-covered-msi=95 --logger-github"
+        ],
+
+        "ci-php-cs-fixer": [
+            "@php-cs-fixer --format=junit --show-progress=dots"
+        ],
+
+        "ci-phpstan": [
+            "@phpstan --error-format=github --xdebug 1"
+        ],
+
+        "install-infection-phar" : [
+            "@php -r \"copy('https://github.com/infection/infection/releases/download/0.26.21/infection.phar', 'vendor/bin/infection.phar');\"",
+            "chmod +x vendor/bin/infection.phar"
+        ],
+
+        "install-git-hooks": [
+            "cp .github/hooks/* .git/hooks/",
+            "chmod +x .git/hooks/*"
+        ],
+
+        "post-install-cmd": [
+            "@install-infection-phar",
+            "@install-git-hooks"
         ]
+
 
     },
     "minimum-stability": "stable",
@@ -64,14 +96,15 @@
         "ext-intl": "*",
         "phpunit/phpunit": "^9",
         "mockery/mockery": "^1.5",
-        "squizlabs/php_codesniffer": "^3.7",
         "phpmd/phpmd": "^2.13",
         "friendsofphp/php-cs-fixer": "^3.16",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.10",
+        "nunomaduro/phpinsights": "^2.8"
     },
     "config": {
         "allow-plugins": {
-            "infection/extension-installer": true
+            "infection/extension-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         ],
 
         "ci-phpinsights": [
-            "@phpinsights --min-quality=95  --min-complexity=70 --min-architecture=80 --min-style=80 --format=github-action"
+            "@phpinsights --min-quality=95  --min-complexity=70 --min-architecture=80 --min-style=80"
         ],
 
         "ci-phpunit" : [

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         ],
 
         "ci-phpstan": [
-            "@phpstan --error-format=github --xdebug 1"
+            "@phpstan --error-format=github --xdebug"
         ],
 
         "install-infection-phar" : [

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         ],
 
         "ci-infection": [
-            "@infection --min-msi=95 --min-covered-msi=95 --logger-github"
+            "@infection --min-msi=95 --min-covered-msi=95 --debug"
         ],
 
         "ci-php-cs-fixer": [

--- a/infection.json
+++ b/infection.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/infection/infection/master/resources/schema.json",
+    "$schema": "vendor/infection/infection/resources/schema.json",
     "source": {
         "directories": [
             "src"


### PR DESCRIPTION
This PR:
- adds phpinsights and enables it in github workflow
- changed reporting options of workflow to always produce github-actions or junit compatible output 
- removed codesniffer (too many cooks, I won't be able to satisfy any of them)
- added basic github workflow badges